### PR TITLE
Updated to work with latest hcl code.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -46,7 +46,7 @@ func TestConfigParsing(t *testing.T) {
 }
 
 const testConfig = `region = "us-west-2"
-region = "something"
+access_key = "something"
 secret_key = "something_else"
 bucket = "backups"
 


### PR DESCRIPTION
Related to #2, while there is a lot less code now after changing it to work with latest hcl code, i think that your example and blog are still one of the only places where it is well documented for someone who wants to uses hcl in non hashicorp codebase. 
The only other alternative is to look through the hcl code (e.g. decoder.go) and/or one of the projects that depend on it like terraform which is not always ideal.
